### PR TITLE
Silence the pnpm warning about sharp's ignored build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,10 @@
     "overrides": {
       "postcss": "^8.5.26",
       "nanoid": "^3.3.18"
-    }
+    },
+    "ignoredBuiltDependencies": [
+      "sharp"
+    ]
   },
   "devDependencies": {
     "@eslint/js": "^9.39.5",


### PR DESCRIPTION
Follow-up to #5 — this one-line change was pushed to `redesign-timetable` just after that PR merged, so it never landed.

Every Vercel build log currently carries:

```
Ignored build scripts: sharp@0.34.5.
Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
```

pnpm 10 blocks dependency install scripts by default. This declares the decision explicitly instead of leaving the warning in every log.

## Why ignore rather than approve

Skipping sharp's script is correct here, not merely tolerable:

- **sharp is unused by this project.** It's an optional dependency of `next`, reachable only from `next/dist/server/image-optimizer` — i.e. `next/image`, which appears nowhere in the codebase. `next/og` powers the icon and OG routes and doesn't touch sharp. On Vercel, image optimization happens at the platform level regardless.
- **The script is a no-op on Vercel.** `sharp/install/check` only acts when a globally-installed libvips is detected or `--build-from-source` is passed. Neither applies on a Vercel build image.
- **Binaries don't depend on it.** They arrive as ordinary `optionalDependencies` (`@img/sharp-*`), which pnpm installs whether or not scripts are approved.

`pnpm approve-builds` — what the warning suggests — writes `onlyBuiltDependencies` instead, running a script that does nothing here while widening the supply-chain surface. `ignoredBuiltDependencies` silences the warning **without** granting script execution, keeping pnpm 10's blocking default intact.

## Verification

Two clean `--frozen-lockfile` installs differing only in this field:

- **without it** — the warning reproduces verbatim
- **with it** — no warning, and `@img/sharp-darwin-arm64@0.34.5` is still installed

In the fixed install, `sharp@0.34.5` loads and encodes a PNG (libvips 8.17.3), confirming nothing breaks by skipping the script.

`package.json` is the only changed file — the lockfile is unaffected. Build and lint clean against current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)