### PR TITLE
Link the two Hamburg sprints to their Livelox events

### DIFF
--- a/lib/data.ts
+++ b/lib/data.ts
@@ -92,9 +92,10 @@ export const DOMAIN_CONFIGS = {
     // Names, dates and OResults event IDs are taken from oresults.eu
     // (events 3655-3658, 28.-30.08.2026).
     //
-    // Livelox URLs are still empty: the events are not set up there yet. The
-    // card hides the Livelox link while `liveloxUrl` is "", so an empty string
-    // is the correct placeholder - do not use a dummy URL.
+    // Livelox has the two sprints ("1./2. Lauf"); Prolog and Mitteldistanz are
+    // not set up there yet. The card hides the Livelox link while `liveloxUrl`
+    // is "", so an empty string is the correct placeholder - do not use a
+    // dummy URL.
     competitions: [
       {
         id: 1,
@@ -111,7 +112,8 @@ export const DOMAIN_CONFIGS = {
         startTime: "2026-08-29T11:00:00+02:00",
         endTime: "2026-08-29T14:00:00+02:00",
         liveResultsUrl: "https://oresults.eu/events/3656/results",
-        liveloxUrl: "",
+        liveloxUrl:
+          "https://www.livelox.com/Events/Show/199868/Hamburg-Sprint-2026-1-Lauf",
       },
       {
         id: 3,
@@ -119,7 +121,8 @@ export const DOMAIN_CONFIGS = {
         startTime: "2026-08-29T15:00:00+02:00",
         endTime: "2026-08-29T18:00:00+02:00",
         liveResultsUrl: "https://oresults.eu/events/3657/results",
-        liveloxUrl: "",
+        liveloxUrl:
+          "https://www.livelox.com/Events/Show/199869/Hamburg-Sprint-2026-2-Lauf",
       },
       {
         id: 4,


### PR DESCRIPTION
The 2026 sprints are now published on Livelox as "1. Lauf" (199868) and "2. Lauf" (199869), so Sprint 1 and Sprint 2 can point at them instead of hiding the link behind an empty URL.

Prolog and Mitteldistanz are still not set up on Livelox and keep their empty placeholder; the comment above the competitions is updated so it no longer claims all four are missing.


Claude-Session: https://claude.ai/code/session_013LktqQ6wR59WczJMSVqGKF